### PR TITLE
Excluding posts from their author's history

### DIFF
--- a/justnobot.py
+++ b/justnobot.py
@@ -160,7 +160,7 @@ def get_posts(subreddit):
         elif post.author is not None and is_marked(post) == 0:
             history = []
             for link in post.author.submissions.new(limit=100):
-                if link.subreddit == subreddit.display_name:
+                if link.subreddit == subreddit.display_name and post.id != link.id:
                     history.append(link)
 
             message = ''            


### PR DESCRIPTION
The history section of u/TheJustNoBot's comment includes the post that the comment was made on. 
Including the current post in the history is confusing.